### PR TITLE
Updates for live hw testing

### DIFF
--- a/protocol/identify.go
+++ b/protocol/identify.go
@@ -111,7 +111,12 @@ func GetChassisIdentify(config map[string]string) (string, error) {
 	case IdentifyOff:
 		state = "off"
 	case IdentifyUnsupported:
-		return "", fmt.Errorf("chassis identify unsupported (identify state: %v)", identifyState)
+		// Unclear that this should be an error, since this is optionally
+		// specified. This setting is optional for IPMI 2.0 according to the
+		// spec and it just means that the "chassis identify command support
+		// [is] unspecified via this command", not that identify support is
+		// unsupported by the BMC.
+		return "", fmt.Errorf("chassis identify not specified as supported (identify state: %v)", identifyState)
 	default:
 		return "", fmt.Errorf("unsupported identify state: %v", identifyState)
 	}

--- a/protocol/power.go
+++ b/protocol/power.go
@@ -27,7 +27,7 @@ func GetChassisPowerState(config map[string]string) (string, error) {
 	}
 
 	var state string
-	switch response.PowerState {
+	switch uint8(response.PowerState) & 1 {
 	case 0:
 		state = "off"
 	case 1:

--- a/protocol/power.go
+++ b/protocol/power.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	powerOn  = 0x01
+	powerOn = 0x01
 )
 
 // GetChassisPowerState gets the current state (on/off) of the chassis.

--- a/protocol/power.go
+++ b/protocol/power.go
@@ -1,10 +1,12 @@
 package protocol
 
 import (
-	"fmt"
-
 	"github.com/vapor-ware/goipmi"
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
+)
+
+const (
+	powerOn  = 0x01
 )
 
 // GetChassisPowerState gets the current state (on/off) of the chassis.
@@ -27,13 +29,15 @@ func GetChassisPowerState(config map[string]string) (string, error) {
 	}
 
 	var state string
-	switch uint8(response.PowerState) & 1 {
-	case 0:
-		state = "off"
-	case 1:
+
+	// Check the power state. According to the IPMI spec, Section 28.2, table 28:
+	// Get Chassis Status Command, power on/off state is held in bit 0 of the
+	// Current Power State byte, where 1b = system power is on, 0b = system power
+	// is off
+	if response.PowerState&1 == powerOn {
 		state = "on"
-	default:
-		return "", fmt.Errorf("unknown power state response: %v", response.PowerState)
+	} else {
+		state = "off"
 	}
 
 	return state, nil


### PR DESCRIPTION
with these changes, verified (to the best that I can verify remotely) that the following work via the plugin:
- power read
- power write
  - on
  - off
  - reset
  - cycle
- led (identify) read**
- led (identify) write
  - on
  - off
- boot target read
- boot target write
  - none
  - pxe


This was tested by using Synse Server to perform reads/writes w/ this plugin (verifying that the read matched the expected output for the given last write), and then verifying the state again via ipmitool.

This PR fixes a bug in the power state reads where the proper bit mask wasn't being applied to get power state. 

** LED read did not "work" with the BMC, in that it did not give an LED (identify) reading, but it did behave as expected. According to the IPMI 2.0 spec, reading LED (identify) state is optionally supported. The inability to read identify state does not mean that setting identify state is not supported.