### PR TITLE
use 1.13 as golang image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder Image
 #
-FROM vaporio/golang:1.11 as builder
+FROM vaporio/golang:1.13 as builder
 
 #
 # Final Image


### PR DESCRIPTION
This PR:
- Updates the Dockerfile base image from `vaporio/golang:1.11` (deprecated) to `vaporio/golang:1.13`

fixes #15 