### PR TITLE
feat: cache bmc clients so they only need to be created once

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vapor-ware/synse-ipmi-plugin
 go 1.13
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/vapor-ware/goipmi v0.0.0-20180502202223-0bfe430a1c35

--- a/pkg/bmcs/manager.go
+++ b/pkg/bmcs/manager.go
@@ -1,0 +1,23 @@
+package bmcs
+
+import (
+	"fmt"
+
+	ipmi "github.com/vapor-ware/goipmi"
+)
+
+var registeredBMCs = map[string]*ipmi.Client{}
+
+// Get the IPMI client for the given BMC ID.
+func Get(bmcID string) (*ipmi.Client, error) {
+	client, found := registeredBMCs[bmcID]
+	if !found {
+		return nil, fmt.Errorf("no BMC with id %s found", bmcID)
+	}
+	return client, nil
+}
+
+// Add a new IPMI client for the given BMC ID.
+func Add(bmcID string, client *ipmi.Client) {
+	registeredBMCs[bmcID] = client
+}

--- a/pkg/bmcs/utils.go
+++ b/pkg/bmcs/utils.go
@@ -1,0 +1,17 @@
+package bmcs
+
+import "fmt"
+
+// GetIDFromConfig gets the BMC ID which is embedded in the device config on
+// dynamic configuration at startup.
+func GetIDFromConfig(config map[string]interface{}) (string, error) {
+	bmcID, found := config["bmc"]
+	if !found {
+		return "", fmt.Errorf("BMC ID not found in device data")
+	}
+	conv, ok := bmcID.(string)
+	if !ok {
+		return "", fmt.Errorf("BMC ID stored in device data in invalid format: must be string")
+	}
+	return conv, nil
+}

--- a/pkg/protocol/boot_target.go
+++ b/pkg/protocol/boot_target.go
@@ -6,12 +6,7 @@ import (
 )
 
 // GetChassisBootTarget gets the current boot device for the chassis.
-func GetChassisBootTarget(config map[string]interface{}) (string, error) {
-	client, err := newClientFromConfig(config)
-	if err != nil {
-		return "", err
-	}
-
+func GetChassisBootTarget(client *ipmi.Client) (string, error) {
 	request := &ipmi.Request{
 		NetworkFunction: ipmi.NetworkFunctionChassis,
 		Command:         ipmi.CommandGetSystemBootOptions,
@@ -21,8 +16,7 @@ func GetChassisBootTarget(config map[string]interface{}) (string, error) {
 	}
 	response := &ipmi.SystemBootOptionsResponse{}
 
-	err = client.Send(request, response)
-	if err != nil {
+	if err := client.Send(request, response); err != nil {
 		return "", err
 	}
 
@@ -34,12 +28,7 @@ func GetChassisBootTarget(config map[string]interface{}) (string, error) {
 }
 
 // SetChassisBootTarget sets the boot device for the chassis.
-func SetChassisBootTarget(config map[string]interface{}, target ipmi.BootDevice) error {
-	client, err := newClientFromConfig(config)
-	if err != nil {
-		return err
-	}
-
+func SetChassisBootTarget(client *ipmi.Client, target ipmi.BootDevice) error {
 	log.WithFields(log.Fields{
 		"target": target.String(),
 	}).Info("[ipmi] setting chassis boot target")

--- a/pkg/protocol/identify.go
+++ b/pkg/protocol/identify.go
@@ -83,12 +83,7 @@ func Identify(c *ipmi.Client, time int) error {
 }
 
 // GetChassisIdentify gets the current identify state from the chassis.
-func GetChassisIdentify(config map[string]interface{}) (string, error) {
-	client, err := newClientFromConfig(config)
-	if err != nil {
-		return "", err
-	}
-
+func GetChassisIdentify(client *ipmi.Client) (string, error) {
 	request := &ipmi.Request{
 		NetworkFunction: ipmi.NetworkFunctionChassis,
 		Command:         ipmi.CommandChassisStatus,
@@ -96,8 +91,7 @@ func GetChassisIdentify(config map[string]interface{}) (string, error) {
 	}
 	response := &ipmi.ChassisStatusResponse{}
 
-	err = client.Send(request, response)
-	if err != nil {
+	if err := client.Send(request, response); err != nil {
 		return "", err
 	}
 
@@ -121,16 +115,11 @@ func GetChassisIdentify(config map[string]interface{}) (string, error) {
 		return "", fmt.Errorf("unsupported identify state: %v", identifyState)
 	}
 
-	return state, err
+	return state, nil
 }
 
 // SetChassisIdentify sets the identify state of the chassis
-func SetChassisIdentify(config map[string]interface{}, state IdentifyState) error {
-	client, err := newClientFromConfig(config)
-	if err != nil {
-		return err
-	}
-
+func SetChassisIdentify(client *ipmi.Client, state IdentifyState) error {
 	var time int
 	switch state {
 	case IdentifyOn:

--- a/pkg/protocol/power.go
+++ b/pkg/protocol/power.go
@@ -10,12 +10,7 @@ const (
 )
 
 // GetChassisPowerState gets the current state (on/off) of the chassis.
-func GetChassisPowerState(config map[string]interface{}) (string, error) {
-	client, err := newClientFromConfig(config)
-	if err != nil {
-		return "", err
-	}
-
+func GetChassisPowerState(client *ipmi.Client) (string, error) {
 	request := &ipmi.Request{
 		NetworkFunction: ipmi.NetworkFunctionChassis,
 		Command:         ipmi.CommandChassisStatus,
@@ -23,8 +18,7 @@ func GetChassisPowerState(config map[string]interface{}) (string, error) {
 	}
 	response := &ipmi.ChassisStatusResponse{}
 
-	err = client.Send(request, response)
-	if err != nil {
+	if err := client.Send(request, response); err != nil {
 		return "", err
 	}
 
@@ -41,21 +35,16 @@ func GetChassisPowerState(config map[string]interface{}) (string, error) {
 	}
 
 	log.WithFields(log.Fields{
-		"state":  state,
+		"state": state,
 	}).Debug("[ipmi] got chassis power state")
 
 	return state, nil
 }
 
 // SetChassisPowerState sets the state of the chassis.
-func SetChassisPowerState(config map[string]interface{}, control ipmi.ChassisControl) error {
-	client, err := newClientFromConfig(config)
-	if err != nil {
-		return err
-	}
-
+func SetChassisPowerState(client *ipmi.Client, control ipmi.ChassisControl) error {
 	log.WithFields(log.Fields{
-		"state":  control.String(),
+		"state": control.String(),
 	}).Info("[ipmi] setting chassis power state")
 	return client.Control(control)
 }

--- a/pkg/protocol/utils.go
+++ b/pkg/protocol/utils.go
@@ -5,9 +5,9 @@ import (
 	ipmi "github.com/vapor-ware/goipmi"
 )
 
-// newClientFromConfig is a utility function to create a new IPMI client
+// NewClientFromConfig is a utility function to create a new IPMI client
 // using the configuration specified in a Device's Data field.
-func newClientFromConfig(config map[string]interface{}) (*ipmi.Client, error) {
+func NewClientFromConfig(config map[string]interface{}) (*ipmi.Client, error) {
 	conn := &ipmi.Connection{}
 
 	if err := mapstructure.Decode(config, conn); err != nil {


### PR DESCRIPTION
This PR:
- adds some basic client caching to reduce the multiple places where client (re)creation occurs. Instead of having to create and connect to the BMC for every single request and on startup for device setup, this change creates the client at setup and subsequent reads/writes lookup the client from cache.
- this also simplifies some of the function signatures/logic which will make writing unit tests against this plugin easier.