### PR TITLE
docker: update vaporio/foundation to bionic tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM vaporio/foundation:xenial
+FROM vaporio/foundation:bionic
 
 LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.name="vaporio/ipmi-plugin" \
@@ -7,7 +7,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.vendor="Vapor IO"
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ipmitool \
+ && apt-get install -y --no-install-recommends ipmitool ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
 COPY synse-ipmi-plugin ./plugin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@
 # to exec into a contain and dig into whatever may be going on inside.
 #
 
-FROM vaporio/foundation:xenial
+FROM vaporio/foundation:bionic
 
 WORKDIR /synse
 


### PR DESCRIPTION
This PR:
- updates the base Dockerfile image to `vaporio/foundation:bionic` from :`xenial`
- adds the `ca-certificates` package,  which should  have been installed  previously